### PR TITLE
Create sg.md

### DIFF
--- a/_gtfobins/sg.md
+++ b/_gtfobins/sg.md
@@ -1,0 +1,16 @@
+---
+functions:
+  shell:  
+    - code: |
+        GROUPNAME=users
+        sg $GROUPNAME -c "/bin/sh"
+  command:
+    - code: |
+        COMMAND=whoami   
+        GROUPNAME=users
+        sg $GROUPNAME -c $COMMAND
+  sudo:
+    - code: |
+        GROUPNAME=users
+        sudo sg $GROUPNAME -c "/bin/sh"
+---


### PR DESCRIPTION
Adding the "sg" binary which allows command execution under a "different" group ID. However, it can be used to break out of restricted environments by using a user's own group ID.